### PR TITLE
Allow hotfix branch pattern

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,19 @@ inputs:
 
     required: false
 
+  hotfix-branch-prefix:
+    description:
+      Branch prefix allowed for hotfix. Tags on this branch will set is_hotfix to true.
+
+      Make sure the branch is available with git fetch (if fetch-depth is unset or > 0)
+
+      ```yaml
+      - name: Fetch hotfix branch (for action-metadata commit check)
+        run: |
+        git fetch --no-tags --prune --depth=1000 origin '+refs/heads/stable/*:refs/remotes/origin/stable/*'
+      ```
+    required: false
+
 outputs:
   publishable:
     description: |
@@ -68,9 +81,11 @@ runs:
       run: |
         PUBLISHABLE=false
         IS_RELEASE=false
+        IS_HOTFIX=false
         VERSION=0.0.0-SNAPSHOT
         DEFAULT_BRANCH=${{ github.event.repository.default_branch }}
         RELEASE_BRANCH=${{ inputs.release-branch }}
+        HOTFIX_BRANCH_PREFIX=${{ inputs.hotfix-branch-prefix }}
 
         LATEST_VERSION=${{ steps.latest.outputs.tag }}
         LATEST_VERSION=${LATEST_VERSION#v}
@@ -88,6 +103,16 @@ runs:
         if [[ $GITHUB_REF =~ refs/tags/v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
           VERSION=${GITHUB_REF#refs/tags/v}
           PUBLISHABLE=$(git merge-base --is-ancestor "$GITHUB_SHA" "origin/$RELEASE_BRANCH" && echo "true" || echo "false")
+
+          if [[ "$PUBLISHABLE" == "false" && ! -z "$HOTFIX_BRANCH_PREFIX" ]]; then
+            # Maybe we have an hotfix. Must be ancestor to the corresponding stable hotfix branch
+            HOTFIX_BRANCH="${HOTFIX_BRANCH_PREFIX%/}/v${VERSION%.*}.x"
+            PUBLISHABLE=$(git merge-base --is-ancestor "$GITHUB_SHA" "origin/$HOTFIX_BRANCH" && echo "true" || echo "false")
+            if [[ "PUBLISHABLE" == "true" ]]; then
+              IS_HOTFIX="true"
+            fi
+          fi
+
           IS_RELEASE="$PUBLISHABLE"
         elif [[ $GITHUB_REF == refs/tags/* ]]; then
           VERSION=$(echo ${GITHUB_REF#refs/tags/} | sed -r 's#/+#-#g')
@@ -103,6 +128,7 @@ runs:
           VERSION=pr-${{ github.event.number }}
         fi
 
-        echo ::set-output name=is-release::$IS_RELEASE
-        echo ::set-output name=publishable::$PUBLISHABLE
-        echo ::set-output name=version::$VERSION
+        echo "is-release=$IS_RELEASE" >> $GITHUB_OUTPUT
+        echo "publishable=$PUBLISHABLE" >> $GITHUB_OUTPUT
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "is-hotfix=$IS_HOTFIX" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ inputs:
     required: false
 
   hotfix-branch-prefix:
-    description:
+    description: |
       Branch prefix allowed for hotfix. Tags on this branch will set is_hotfix to true.
 
       Make sure the branch is available with git fetch (if fetch-depth is unset or > 0)

--- a/action.yml
+++ b/action.yml
@@ -107,9 +107,13 @@ runs:
           if [[ "$PUBLISHABLE" == "false" && ! -z "$HOTFIX_BRANCH_PREFIX" ]]; then
             # Maybe we have an hotfix. Must be ancestor to the corresponding stable hotfix branch
             HOTFIX_BRANCH="${HOTFIX_BRANCH_PREFIX%/}/v${VERSION%.*}.x"
-            PUBLISHABLE=$(git merge-base --is-ancestor "$GITHUB_SHA" "origin/$HOTFIX_BRANCH" && echo "true" || echo "false")
-            if [[ "PUBLISHABLE" == "true" ]]; then
-              IS_HOTFIX="true"
+            if [[ ! -z "$(git ls-remote --heads origin ${HOTFIX_BRANCH})" ]]; then
+              PUBLISHABLE=$(git merge-base --is-ancestor "$GITHUB_SHA" "origin/$HOTFIX_BRANCH" && echo "true" || echo "false")
+              if [[ "PUBLISHABLE" == "true" ]]; then
+                IS_HOTFIX="true"
+              fi
+            else
+              echo "Hotfix branch '${HOTFIX_BRANCH}' does not exists. Could not publish tag '${VERSION}'"
             fi
           fi
 
@@ -132,3 +136,11 @@ runs:
         echo "publishable=$PUBLISHABLE" >> $GITHUB_OUTPUT
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "is-hotfix=$IS_HOTFIX" >> $GITHUB_OUTPUT
+
+        echo "### Aplication metadata" >> $GITHUB_STEP_SUMMARY
+        echo "|Output|Value|" >> $GITHUB_STEP_SUMMARY
+        echo "|:---|:---|" >> $GITHUB_STEP_SUMMARY
+        echo "|__is-release__|$IS_RELEASE|" >> $GITHUB_STEP_SUMMARY
+        echo "|__publishable__|$PUBLISHABLE|" >> $GITHUB_STEP_SUMMARY
+        echo "|__version__|$VERSION|" >> $GITHUB_STEP_SUMMARY
+        echo "|__is-hotfix__|$IS_HOTFIX|" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Nouvelle option inputs.hotfix-branch-prefix

Si  hotfix-branch-prefix l'action se comporte comme avant
Sinon
penons pour exemple 
release-branch=stable/main
hotfix-branch-prefix=stable/

Si le commit du tag n'est pas un ancêtre de stable/main on vérifie s'il est un  ancêtre de la branche correspondante au nom du tag.
Si le tag est 1.2.3 la branche serait stable/v1.2.x

J'ai testé le script batch dans un shell

Bonus, je corrige les set-output

Testé ici : https://github.com/kronostechnologies/kronos-crm/actions/runs/3388556764