### PR TITLE
Ignore failure if no v. tag is found

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,6 +68,7 @@ runs:
     - name: Find latest released version
       id: latest
       uses: oprypin/find-latest-tag@v1.1.1
+      continue-on-error: true
       with:
         repository: ${{ github.repository }}
         releases-only: false


### PR DESCRIPTION
We initially suported this but support for continue-on-error was missing from composites when we created this action. The script already defaults to 0.0.0 if no v* tag exists. This happens on brand new projects.