### PR TITLE
feat: support workflow_run triggers

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,9 +84,22 @@ runs:
         IS_RELEASE=false
         IS_HOTFIX=false
         VERSION=0.0.0-SNAPSHOT
+        EVENT=${{ github.event_name }}
         DEFAULT_BRANCH=${{ github.event.repository.default_branch }}
         RELEASE_BRANCH=${{ inputs.release-branch }}
         HOTFIX_BRANCH_PREFIX=${{ inputs.hotfix-branch-prefix }}
+
+        if [[ $EVENT == "workflow_run" ]]; then
+          SOURCE_EVENT=${{ github.event.workflow_run.event }}
+          REF=${{ github.event.workflow_run.head_branch }}
+          SHA=${{ github.event.workflow_run.head_sha}}
+        else
+          SOURCE_EVENT=$EVENT
+          REF=${{ github.ref }}
+          REF=${REF#refs/tags/}
+          REF=${REF#refs/heads/}
+          SHA=${{ github.sha }}
+        fi
 
         LATEST_VERSION=${{ steps.latest.outputs.tag }}
         LATEST_VERSION=${LATEST_VERSION#v}
@@ -94,23 +107,23 @@ runs:
 
         if [[ "$DEFAULT_BRANCH" == "" ]]; then
           # Schedule triggers have no `github.event` contexts
-          DEFAULT_BRANCH="${GITHUB_REF#refs/heads/}"
+          DEFAULT_BRANCH="$REF"
         fi
 
         if [[ "$RELEASE_BRANCH" == "" ]]; then
           RELEASE_BRANCH="$DEFAULT_BRANCH"
         fi
 
-        if [[ $GITHUB_REF =~ refs/tags/v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-          VERSION=${GITHUB_REF#refs/tags/v}
-          PUBLISHABLE=$(git merge-base --is-ancestor "$GITHUB_SHA" "origin/$RELEASE_BRANCH" && echo "true" || echo "false")
+        if [[ $REF =~ v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+          VERSION=${REF#v}
+          PUBLISHABLE=$(git merge-base --is-ancestor "$SHA" "origin/$RELEASE_BRANCH" && echo "true" || echo "false")
 
           if [[ "$PUBLISHABLE" == "false" && ! -z "$HOTFIX_BRANCH_PREFIX" ]]; then
             # Maybe we have an hotfix. Must be ancestor to the corresponding stable hotfix branch
             HOTFIX_BRANCH="${HOTFIX_BRANCH_PREFIX%/}/v${VERSION%.*}.x"
             if [[ ! -z "$(git ls-remote --heads origin ${HOTFIX_BRANCH})" ]]; then
-              PUBLISHABLE=$(git merge-base --is-ancestor "$GITHUB_SHA" "origin/$HOTFIX_BRANCH" && echo "true" || echo "false")
-              if [[ "PUBLISHABLE" == "true" ]]; then
+              PUBLISHABLE=$(git merge-base --is-ancestor "$SHA" "origin/$HOTFIX_BRANCH" && echo "true" || echo "false")
+              if [[ "$PUBLISHABLE" == "true" ]]; then
                 IS_HOTFIX="true"
               fi
             else
@@ -119,18 +132,17 @@ runs:
           fi
 
           IS_RELEASE="$PUBLISHABLE"
-        elif [[ $GITHUB_REF == refs/tags/* ]]; then
-          VERSION=$(echo ${GITHUB_REF#refs/tags/} | sed -r 's#/+#-#g')
-        elif [[ $GITHUB_REF == refs/heads/* ]]; then
-          BRANCH=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-          if [ "$DEFAULT_BRANCH" = "$BRANCH" ]; then
-            VERSION=${LATEST_VERSION%.*}.$((${LATEST_VERSION##*.} + 1))-SNAPSHOT
-            PUBLISHABLE=true
+        elif [[ $SOURCE_EVENT == "pull_request" ]]; then
+          if [[ $EVENT == "workflow_run" ]]; then
+            VERSION=pr-${{ github.event.workflow_run.pull_requests[0].number }}
           else
-            VERSION=branch-$BRANCH
+            VERSION=pr-${{ github.event.number }}
           fi
-        elif [[ $GITHUB_REF == refs/pull/* ]]; then
-          VERSION=pr-${{ github.event.number }}
+        elif [[ $DEFAULT_BRANCH == $REF ]]; then
+          VERSION=${LATEST_VERSION%.*}.$((${LATEST_VERSION##*.} + 1))-SNAPSHOT
+          PUBLISHABLE=true
+        else
+          VERSION=ref-$REF
         fi
 
         echo "is-release=$IS_RELEASE" >> $GITHUB_OUTPUT
@@ -141,7 +153,9 @@ runs:
         echo "### Aplication metadata" >> $GITHUB_STEP_SUMMARY
         echo "|Output|Value|" >> $GITHUB_STEP_SUMMARY
         echo "|:---|:---|" >> $GITHUB_STEP_SUMMARY
+        echo "|__REF__|$REF|" >> $GITHUB_STEP_SUMMARY
+        echo "|__SHA__|$SHA|" >> $GITHUB_STEP_SUMMARY
+        echo "|__is-hotfix__|$IS_HOTFIX|" >> $GITHUB_STEP_SUMMARY
         echo "|__is-release__|$IS_RELEASE|" >> $GITHUB_STEP_SUMMARY
         echo "|__publishable__|$PUBLISHABLE|" >> $GITHUB_STEP_SUMMARY
         echo "|__version__|$VERSION|" >> $GITHUB_STEP_SUMMARY
-        echo "|__is-hotfix__|$IS_HOTFIX|" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Ça va aider à séparer les workflows qui dépendent de nos workflows principaux, mais ne rentre pas pas nécessairement dans le moule habituel.

`workflow_run` mélange les tags et branches et ne fournit pas le préfixe `refs/heads/` ou `refs/tags` alors j'ai dû ajuster la logique. J'ai aussi créé une nouvelle règle sur l'organisation pour bloquer les tags "main" ou "master". On bloquait déjà les branches "v*".

Lorsqu'on utilise `workflow_run`, on doit être explicite sur le sha à checkout: le workflow roule dans le contexte de la branche par défaut. Ça aussi permettre d'utiliser des environnements protégés qui ne sont pas accessible dans la PR (ie séparer proprement la partie CD qui nécessaite divers accès en écriture).

Un exemple d'usage:

```yaml
on:
  workflow_run:
    types: [completed]
    workflows: [App]
    branches: ["main", "v*"]  # workflow_run mixes branches and tags

jobs:
  release-something:
    name: Release some library
    runs-on: ubuntu-latest
    if: github.event.workflow_run.conclusion == 'success'
    steps:
      - uses: actions/checkout@v3
        with:
          fetch-depth: 0
          ref: ${{ github.event.workflow_run.head_sha }}
      - name: Find application metadata
        id: metadata
        uses: equisoft-actions/application-metadata@v1
```