### PR TITLE
Fix regex when tags has date as revision number

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -114,7 +114,8 @@ runs:
           RELEASE_BRANCH="$DEFAULT_BRANCH"
         fi
 
-        if [[ $REF =~ v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+        # Note: Sometimes we use 14-character date as a revision number
+        if [[ $REF =~ v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,14}$ ]]; then
           VERSION="${REF#v}"
           PUBLISHABLE="$(git merge-base --is-ancestor "$SHA" "origin/$RELEASE_BRANCH" && echo "true" || echo "false")"
 


### PR DESCRIPTION
Par exemple pour les images de base on utilise la date (14 caractères) comme revision number du tags, par exemple v1.2.20231105001727.

Actuellement ça donne les tags suivants "v1.2, version-v1.2.20231029001656, vv1.2.20231029001656, v1, latest", mais en réalité on veut "v1.2, version-1.2.20231029001656, v1.2.20231029001656, v1, latest, 1". En tenant mieux compte dans la regex de la situation (exceptionnel) de la date, ça devrait fonctionner.