### PR TITLE
fix typo in is-hotfix output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,8 @@ outputs:
       'false' if this build should not publish its artifacts.
     value: ${{ steps.metadata.outputs.publishable }}
   is-hotfix:
-    description: 'true' if this build is a hotfix
+    description: |
+      'true' if this build is a hotfix
     value: ${{ steps.metadata.outputs.is-hotfix }}
   is-release:
     description: |


### PR DESCRIPTION
```
Error: equisoft-actions/application-metadata/v1/action.yml: (Line: 54, Col: 25, Idx: 1717) - (Line: 54, Col: 50, Idx: 1742): While parsing a block mapping, did not find expected key.
36
Error: System.ArgumentException: Unexpected type '' encountered while reading 'action manifest root'. The type 'MappingToken' was expected.
```